### PR TITLE
tilemap indexbuffer can no longer be destroyed

### DIFF
--- a/src/TilemapPipe.ts
+++ b/src/TilemapPipe.ts
@@ -71,6 +71,10 @@ export class TilemapPipe implements RenderPipe<Tilemap>, InstructionPipe<Tilemap
             label: 'index-tilemap-buffer',
             usage: BufferUsage.INDEX | BufferUsage.COPY_DST,
         });
+		// Remove the destroy method from the index buffer to prevent it from being destroyed.
+		// This is because the index buffer is shared between all tilemaps, and .destroy will be called when destroying a tilemap.
+        this.indexBuffer.destroy = () => {};
+
 	    this.checkIndexBuffer(2000);
     }
 


### PR DESCRIPTION
Currently, there is an issue where the Tilemap pipeline crashes after the first tilemap is destroyed in `TilemapPipe.destroyRenderable`. This immediately crashes the entire application.

This is a bandaid solution, and I haven't tested thoroughly enough to know if any other related issues might pop up.