### PR TITLE
Fix CI/CD errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
         "@webdoc/cli": "^2.2.0",
         "copyfiles": "^2.4.1",
         "npm-run-all": "^4.1.5",
-        "pixi.js": "^8.0.0-X",
+        "pixi.js": "8.5.0",
         "pre-commit": "^1.2.2",
         "rimraf": "^4.1.1",
         "tslib": "^2.6.2",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
-        "pixi.js": ">=8.0.2"
+        "pixi.js": ">=8.5.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -13087,9 +13087,9 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.1.0.tgz",
-      "integrity": "sha512-qclFipWxKavNZoOE0QjGgEklbxjc1mpHf46adsxYLz7O7RnV44PPkq1J5Ssa6y1JxtYUX0fwbphoE/gz276glA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.5.0.tgz",
+      "integrity": "sha512-C3UouBCqZZskKAkI63JrROUDUZF27avtmzq5udyVHJNRK/noZsS38YfQgx6SMANOIuuMSQ3jWnqD07mtCPmpeA==",
       "dev": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "pixi.js": ">=8.0.2"
+    "pixi.js": ">=8.5.0"
   },
   "devDependencies": {
     "@pixi/eslint-config": "^4.0.1",
@@ -56,7 +56,7 @@
     "@webdoc/cli": "^2.2.0",
     "copyfiles": "^2.4.1",
     "npm-run-all": "^4.1.5",
-    "pixi.js": "^8.0.0-X",
+    "pixi.js": "8.5.0",
     "pre-commit": "^1.2.2",
     "rimraf": "^4.1.1",
     "tslib": "^2.6.2",

--- a/src/Tilemap.ts
+++ b/src/Tilemap.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { Bounds, Container, groupD8, State, Texture, TextureSource, ViewContainer } from 'pixi.js';
+import { Bounds, groupD8, State, Texture, TextureSource, ViewContainer } from 'pixi.js';
 import { settings } from './settings';
 import { TilemapInstruction, TilemapPipe } from './TilemapPipe';
 import { TileTextureArray } from './TileTextureArray';
@@ -124,17 +124,17 @@ export class Tilemap extends ViewContainer
     /** The interleaved geometry of the tilemap. */
     private pointsBuf: Array<number> = [];
 
-    protected updateBounds(): void {
-		const bounds = this.tilemapBounds;
+    protected updateBounds(): void
+    {
+        const bounds = this.tilemapBounds;
 
-		this._bounds.minX = bounds.minX;
-		this._bounds.maxX = bounds.maxX;
-		this._bounds.minY = bounds.minY;
-		this._bounds.maxY = bounds.maxY;
+        this._bounds.minX = bounds.minX;
+        this._bounds.maxX = bounds.maxX;
+        this._bounds.minY = bounds.minY;
+        this._bounds.maxY = bounds.maxY;
     }
 
     public batched: boolean;
-
 
     /**
      * @param tileset - The tileset to use for the tilemap. This can be reset later with {@link Tilemap.setTileset}. The
@@ -142,7 +142,7 @@ export class Tilemap extends ViewContainer
      */
     constructor(tileset: TextureSource | Array<TextureSource>)
     {
-        super();
+        super({});
         this.setTileset(tileset);
     }
 

--- a/src/TilemapPipe.ts
+++ b/src/TilemapPipe.ts
@@ -1,7 +1,7 @@
 import {
     Buffer,
     BufferUsage, ExtensionType, GlobalUniformGroup,
-    IndexBufferArray, Instruction, InstructionPipe, InstructionSet, Matrix, Renderer,
+    IndexBufferArray, Instruction, InstructionPipe, InstructionSet, Matrix, NOOP, Renderer,
     RenderPipe, UniformGroup
 } from 'pixi.js';
 import { CompositeTilemap } from './CompositeTilemap';
@@ -71,9 +71,10 @@ export class TilemapPipe implements RenderPipe<Tilemap>, InstructionPipe<Tilemap
             label: 'index-tilemap-buffer',
             usage: BufferUsage.INDEX | BufferUsage.COPY_DST,
         });
-		// Remove the destroy method from the index buffer to prevent it from being destroyed.
-		// This is because the index buffer is shared between all tilemaps, and .destroy will be called when destroying a tilemap.
-        this.indexBuffer.destroy = () => {};
+        // Remove the destroy method from the index buffer to prevent it from being destroyed.
+        // This is because the index buffer is shared between all tilemaps,
+        // and .destroy will be called when destroying a tilemap.
+        this.indexBuffer.destroy = NOOP;
 
 	    this.checkIndexBuffer(2000);
     }


### PR DESCRIPTION
CI/CD has been throwing errors for months now, preventing fixes from being added:
https://github.com/pixijs-userland/tilemap/actions/workflows/main.yml

I went through and fixed both `xs types` and `xs lint`.

This did require an update to the minimum pixi.js version, as tilemap now uses ViewContainer rather than Container.